### PR TITLE
Added missing permission string

### DIFF
--- a/lang/en/block_attendance.php
+++ b/lang/en/block_attendance.php
@@ -26,3 +26,4 @@ $string['attendance:addinstance'] = 'Add a new attendance block';
 $string['blockname'] = 'Attendance';
 $string['needactivity'] = 'This block can work only with an attendance activity. Please add the activity to this course.';
 $string['pluginname'] = 'Attendance';
+$string['attendance:addinstance'] = 'Add a new Attendance block';


### PR DESCRIPTION
I think there was a missing permissions string for attendance:addinstance (e.g. Course administration->Users->Permissions: block/attendance:addinstance).
